### PR TITLE
Fixes Xcode warning about trailing closure

### DIFF
--- a/Chapter 04/myProject/Tests/AppTests/AppTests.swift
+++ b/Chapter 04/myProject/Tests/AppTests/AppTests.swift
@@ -7,9 +7,9 @@ final class AppTests: XCTestCase {
         defer { app.shutdown() }
         try configure(app)
 
-        try app.test(.GET, "hello") { res in
+        try app.test(.GET, "hello", afterResponse:  { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "Hello, world!")
-        }
+        })
     }
 }


### PR DESCRIPTION
Hi, This is my first pull request. Hope i'm doing it right. Got this warning as I am working through your book. Really enjoying it so far!
"Backward matching of the unlabeled trailing closure is deprecated; label the argument with 'afterResponse' to suppress this warning"
